### PR TITLE
add "host" field in json output

### DIFF
--- a/address.go
+++ b/address.go
@@ -16,6 +16,8 @@ type address struct {
 	user   string
 	domain string
 	port   int
+
+	host string
 }
 
 func (address address) String() string {
@@ -58,6 +60,7 @@ func parseAddress(
 		user:   user,
 		domain: domain,
 		port:   port,
+		host:   host,
 	}, nil
 }
 

--- a/command.go
+++ b/command.go
@@ -176,6 +176,7 @@ func runRemoteExecutionNode(
 		stdoutBackend = &jsonOutputWriter{
 			stream: `stdout`,
 			node:   node.String(),
+			host:   node.address.host,
 
 			output: os.Stdout,
 		}
@@ -183,6 +184,7 @@ func runRemoteExecutionNode(
 		stderrBackend = &jsonOutputWriter{
 			stream: `stderr`,
 			node:   node.String(),
+			host:   node.address.host,
 
 			output: os.Stderr,
 		}

--- a/json_output_writer.go
+++ b/json_output_writer.go
@@ -8,6 +8,7 @@ import (
 type jsonOutputWriter struct {
 	stream string
 	node   string
+	host   string
 
 	output io.Writer
 }
@@ -25,6 +26,12 @@ func (writer *jsonOutputWriter) Write(data []byte) (int, error) {
 		message["node"] = nil
 	} else {
 		message["node"] = writer.node
+	}
+
+	if writer.host == "" {
+		message["host"] = nil
+	} else {
+		message["host"] = writer.host
 	}
 
 	message["body"] = string(data)


### PR DESCRIPTION
The "node" field is very inconvenient since a user specifies list of
nodes and then if they wants to parse json output and associate results
with original list of addresses they needs to parse "node" field because
it looks like `[User.Name@ip-address:port]` but a user specified just ip
addresses.

Therefore, we add new field "host" in JSON output which is the same as
specified by user in stdin or in --host flag.