### PR TITLE
fix permanent ssh key password prompt

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,17 +719,6 @@ func createRunnerFactory(
 		keyring = agent.NewKeyring()
 	}
 
-	if sshKeyPath != "" {
-		err := readSSHKey(keyring, sshKeyPath)
-		if err != nil {
-			return nil, hierr.Errorf(
-				err,
-				`can't read SSH key: '%s'`,
-				sshKeyPath,
-			)
-		}
-	}
-
 	return createRemoteRunnerFactoryWithAgent(
 		keyring,
 		timeout,


### PR DESCRIPTION
Orgalorg keeps asking for the ssh key passphrase even when it is unlocked. This small modification fixes this issue.
