### PR TITLE
Prefer ssh-agent keyring instead of ssh-key

### DIFF
--- a/main.go
+++ b/main.go
@@ -713,6 +713,7 @@ func createRunnerFactory(
 	}
 
 	var keyring agent.Agent
+	sshAgentAlive := false
 	if os.Getenv("SSH_AUTH_SOCK") != "" {
 		sock, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 		if err != nil {
@@ -724,11 +725,12 @@ func createRunnerFactory(
 		}
 
 		keyring = agent.NewClient(sock)
+		sshAgentAlive = true
 	} else {
 		keyring = agent.NewKeyring()
 	}
 
-	if sshKeyPath != "" {
+	if !sshAgentAlive && sshKeyPath != "" {
 		err := readSSHKey(keyring, sshKeyPath)
 		if err != nil {
 			return nil, hierr.Errorf(


### PR DESCRIPTION
Another implementation of https://github.com/reconquest/orgalorg/pull/25.

Use ssh-key only if ssh-agent not available to avoid password prompt.
Also fixes missing ssh-key on remote machine (if ssh agent-forwarding is used).