### PR TITLE
build/release fix: bump go to 1.17 to understand //go:build pragma

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
I have noticed the build fails because of the changes I have introduced in the previous PR.

The new `//go:guild` pragma was introduced in 1.17, so it is ignored in 1.15, causing the build errors.

Changing the github actions seem to succeed in the build: https://github.com/cr1cr1/orgalorg/runs/4616026239?check_suite_focus=true